### PR TITLE
Width parameter

### DIFF
--- a/fancyboxmd.py
+++ b/fancyboxmd.py
@@ -1,5 +1,6 @@
 from markdown.extensions import Extension
 from markdown.inlinepatterns import LinkInlineProcessor
+
 import xml.etree.ElementTree as etree
 
 
@@ -29,6 +30,12 @@ class FancyBoxInlineProcessor(LinkInlineProcessor):
         if not handled:
             return None, None, None
 
+        splitted = src.split(",")
+        src = splitted[0]
+        width = self.preview_width
+        if len(splitted) > 1:
+            width = splitted[1].strip()
+
         el_figure = etree.Element("figure")
         el_figcaption = etree.Element("figcaption")
 
@@ -44,7 +51,7 @@ class FancyBoxInlineProcessor(LinkInlineProcessor):
 
         el_img = etree.Element("img")
         el_img.set("src", src)
-        el_img.set("width", self.preview_width)
+        el_img.set("width", width)
         el_img.set("title", title)
         el_img.set('alt', title)
 
@@ -60,7 +67,7 @@ FB_BRACKETS_RE = r"!!\["
 class FancyBoxExtension(Extension):
     """
     The FancyBoxExtension creates fancybox attributes on images using exclamation marks.
-    !![Title](image_url_here.jpg "Description")
+    !![Title](image_url_here.jpg "Description", width)
     """
 
     def __init__(self, **kwargs):

--- a/test.py
+++ b/test.py
@@ -1,0 +1,50 @@
+from markdown.test_tools import TestCase, Kwargs
+from fancyboxmd import FancyBoxExtension
+import markdown
+
+class TestHr(TestCase):
+    default_kwargs = Kwargs(
+        extensions=[FancyBoxExtension()],
+    )
+
+    def test_with_width(self):
+        self.assertMarkdownRenders(
+            # The Markdown source text used as input
+            self.dedent(
+                """
+                !![Registration](../../assets/images/qfieldcloud_registration.png, 69px)
+                """
+            ),
+            # The expected HTML output
+            self.dedent(
+                """
+                <p>
+                <figure><a data-caption="Registration" data-fancybox="gallery" href="../../assets/images/qfieldcloud_registration.png"><img alt="Registration" src="../../assets/images/qfieldcloud_registration.png" title="Registration" width="69px"></a><figcaption>Registration</figcaption>
+                </figure>
+                </p>
+                """
+            ),
+            # Other keyword arguments to pass to `markdown.markdown`
+            output_format='html'
+        )
+
+    def test_without_width(self):
+        self.assertMarkdownRenders(
+            # The Markdown source text used as input
+            self.dedent(
+                """
+                !![Registration](../../assets/images/qfieldcloud_registration.png)
+                """
+            ),
+            # The expected HTML output
+            self.dedent(
+                """
+                <p>
+                <figure><a data-caption="Registration" data-fancybox="gallery" href="../../assets/images/qfieldcloud_registration.png"><img alt="Registration" src="../../assets/images/qfieldcloud_registration.png" title="Registration" width="600px"></a><figcaption>Registration</figcaption>
+                </figure>
+                </p>
+                """
+            ),
+            # Other keyword arguments to pass to `markdown.markdown`
+            output_format='html'
+        )


### PR DESCRIPTION
This PR adds the possibility to define the width of the image. If no width is set, the default value is used.

The syntax is now: `!![Title](image_url_here.jpg, width)`

A more elegant solution would have been to use the attribute list, but this is not possible as described in the documentation https://python-markdown.github.io/extensions/attr_list/ :

> There are various HTML elements which are not represented in Markdown  text, but only implied. For example, the ul and ol elements do not exist in Markdown. They are only implied by the presence of list items (li). There is no way to use an attribute list to define attributes on implied elements, including but not limited to the following: ul, ol, dl, table, thead, tbody, and tr.